### PR TITLE
Added ability to collapse and resize tree container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the USS-Explorer will be documented in this file.
 ### New features and enhancements
 
 - Changed packaging and lifecycle start.sh script to support explorer-ui-server keyring support (https://github.com/zowe/zowe-install-packaging/pull/1177), Thanks @stevenhorsman, @js665999, @nakulmanchanda, @jackjia-ibm
+- Added ability to collapse and resize jobs tree (https://github.com/zowe/zlux/issues/259), Thanks @skurnevich
 
 ### Bug fixes
 

--- a/WebContent/css/responsive-grid.css
+++ b/WebContent/css/responsive-grid.css
@@ -47,10 +47,15 @@
 .col-2 {width: 15.33%;}
 .col-1 {width: 6.866%;}
 
+.col-11-8 {width: 98%; margin-left: 0%;}
+.col-9-2 {width: 72.6%; margin-left: 0%;}
+.col-0-1 {width: 6px; margin: 0 calc(0.5% - 3px); height: 100%;}
+
 /*  FULL WIDTH */
 @media only screen and (max-width: 600px) {
 	.col { margin: 1% 0 1% 0%; }
-    .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12 {
+    .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col-9-2 {
         width: 100%;
 	}
+	.col-0-1{ height: 0; width: 0;}
 }

--- a/WebContent/css/styles.css
+++ b/WebContent/css/styles.css
@@ -83,3 +83,34 @@ body {
     left: 50%;
     transform: translate(-50%, -50%);
 }
+
+.action-layer {
+    height: 100vh;
+    width: 100vw;
+}
+
+.hidden {
+    display: none;
+}
+
+.rotate-180 {
+    transform: rotate(180deg);
+}
+
+.draggable {
+    cursor: col-resize;
+}
+
+.collapse-col {
+    align-items: center;
+    display: flex;
+    justify-content: center;
+}
+
+.collapse-btn {
+    border-radius: 6px !important;
+    display: flex !important;
+    justify-content: center;
+    min-height: 60px;
+    max-width: 20px;
+}

--- a/WebContent/js/components/editor/EditorMenuBar.js
+++ b/WebContent/js/components/editor/EditorMenuBar.js
@@ -95,7 +95,7 @@ export default class EditorMenuBar extends React.Component {
                 {file}
                 {file ? EditorMenuBar.renderFullScreenButton(file) : null}
                 <SelectField
-                    style={{ float: 'right' }}
+                    style={{ float: 'right', width: '120px' }}
                     value={this.state.syntax}
                     onChange={this.handleSyntaxChange}
                 >

--- a/WebContent/js/containers/pages/Home.js
+++ b/WebContent/js/containers/pages/Home.js
@@ -11,28 +11,131 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import KeyboardArrowLeftIcon from 'material-ui/svg-icons/navigation/chevron-left';
+import IconButton from 'material-ui/IconButton';
 import USSTreeComponent from '../USSTree';
 import Editor from '../../components/editor/Editor';
 import ConnectedSnackbar from '../../components/Snackbar';
 import LoginDialog from '../../components/dialogs/LoginDialog';
+import debounce from '../../utilities/debounce';
 
-const HomeView = props => {
-    const { validated } = props;
-    if (validated) {
-        return (
-            <div className="row group">
-                <div className="component col col-3">
-                    <USSTreeComponent id="USSTree" title="Unix File Explorer" subtitle="Browse Unix Files" type="unix" />
-                </div>
-                <div className="component col col-9">
-                    <Editor />
-                </div>
-                <ConnectedSnackbar />
-            </div>
-        );
+const gridOfTwelveCol3 = 0.238;
+const widthForFullScreen = 600;
+const minContainerWidth = 300;
+
+class HomeView extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            moveMode: false,
+            collapsed: false,
+            windowWidth: window.innerWidth,
+            treeWidthPercent: gridOfTwelveCol3,
+        };
+        this.debHandleResize = debounce(this.handleResize, 100);
+        this.debRecalcTreeWidth = debounce(this.recalcTreeWidth, 10);
     }
-    return (<LoginDialog />);
-};
+
+    componentDidMount() {
+        window.addEventListener('resize', this.debHandleResize);
+    }
+
+    componentWillUnmount() {
+        window.removeEventListener('resize', this.debHandleResize);
+    }
+
+    onDraggingStart = event => {
+        if (!this.state.collapsed) {
+            event.preventDefault();
+            this.setState({ moveMode: true });
+        }
+    };
+
+    onDragging = event => {
+        if (this.state.moveMode) {
+            this.debRecalcTreeWidth(event.clientX);
+        }
+    };
+
+    onDraggingEnd = event => {
+        if (this.state.moveMode) {
+            this.debRecalcTreeWidth(event.clientX);
+            this.setState({ moveMode: false });
+        }
+    };
+
+    handleResize = () => {
+        this.setState({ windowWidth: window.innerWidth });
+        const newX = window.innerWidth * this.state.treeWidthPercent;
+        const maxTreeWidth = window.innerWidth - minContainerWidth;
+        if (newX < minContainerWidth) {
+            this.setState({ treeWidthPercent: minContainerWidth / window.innerWidth });
+        }
+        if (newX > maxTreeWidth) {
+            this.setState({ treeWidthPercent: maxTreeWidth / window.innerWidth });
+        }
+    };
+
+    recalcTreeWidth = mouseX => {
+        const maxTreeWidth = window.innerWidth - minContainerWidth;
+        const halfBarWidthCorrection = window.innerWidth * 0.005;
+        let newX = mouseX;
+        if (mouseX < minContainerWidth || mouseX > maxTreeWidth) {
+            newX = (minContainerWidth < mouseX) ? maxTreeWidth : minContainerWidth;
+        }
+        const treeWidthPercent = (newX - halfBarWidthCorrection) / window.innerWidth;
+        this.setState({ treeWidthPercent });
+    };
+
+    render() {
+        if (this.props.validated) {
+            const { collapsed, windowWidth, treeWidthPercent, moveMode } = this.state;
+            return (
+                <div className="row group">
+                    <div
+                        className={moveMode ? 'action-layer draggable' : 'action-layer'}
+                        onMouseUp={this.onDraggingEnd}
+                        onMouseMove={this.onDragging}
+                    >
+                        <div
+                            id="explorer-sidebar"
+                            className={`component col col-3 ${collapsed ? 'hidden' : ''}`}
+                            style={windowWidth <= widthForFullScreen ? {} : { width: `${treeWidthPercent * 100}%` }}
+                        >
+                            <USSTreeComponent id="USSTree" title="Unix File Explorer" subtitle="Browse Unix Files" type="unix" />
+                        </div>
+                        <div
+                            id="resize-bar"
+                            className={`component col col-0-1 collapse-col ${collapsed ? '' : 'draggable'} `}
+                            onMouseDown={this.onDraggingStart}
+                        >
+                            <IconButton
+                                id="collapse-button"
+                                className="collapse-btn"
+                                onClick={() => {
+                                    this.setState({ collapsed: !collapsed });
+                                }}
+                                onMouseDown={e => {
+                                    e.stopPropagation();
+                                }}
+                            >
+                                <KeyboardArrowLeftIcon className={collapsed ? 'rotate-180' : ''} />
+                            </IconButton>
+                        </div>
+                        <div
+                            className={`component col ${collapsed ? 'col-11-8' : 'col-9-2'}`}
+                            style={(collapsed || windowWidth <= widthForFullScreen) ? {} : { width: `calc(100% - ${treeWidthPercent * 100}% - 2%)` }}
+                        >
+                            <Editor />
+                        </div>
+                        <ConnectedSnackbar />
+                    </div>
+                </div>
+            );
+        }
+        return (<LoginDialog />);
+    }
+}
 
 HomeView.propTypes = {
     validated: PropTypes.bool.isRequired,

--- a/WebContent/js/utilities/debounce.js
+++ b/WebContent/js/utilities/debounce.js
@@ -1,0 +1,14 @@
+export default function debounce(func, wait, immediate) {
+    let timeout;
+    return function outputFunc(...params) {
+        const context = this;
+        const later = () => {
+            timeout = null;
+            if (!immediate) func.apply(context, params);
+        };
+        const callNow = immediate && !timeout;
+        clearTimeout(timeout);
+        timeout = setTimeout(later, wait);
+        if (callNow) func.apply(context, params);
+    };
+}


### PR DESCRIPTION
Signed-off-by: Sergei Kurnevich <sergei.kurnevich@broadcom.com>

This PR addresses Issue: https://github.com/zowe/zlux/issues/259

Same update like for JES / MVS Explorers, but had to rewrite HomeView as class, as react 15 does not support hooks.

## PR Type
- [ ] Bug fix
- Feature
- [ ] Other (Please indicate)

## PR Checklist
- PR completes `npm run preCommit` without error
- [ ] Relevant Test cases have been added (Unit and or FVT)
- Relevant update to CHANGELOG.md
- PR from forked repo? Ensure Allow edits by maintaners is set.