### PR TITLE
add https://${ZOWE_EXTERNAL_HOST}:${ZWE_EXTERNAL_PORT} to destination

### DIFF
--- a/pluginDefinition.prod.json
+++ b/pluginDefinition.prod.json
@@ -5,7 +5,7 @@
   "pluginType": "application",
   "webContent": {
     "framework": "iframe",
-    "destination": "/ui/v1/explorer-uss",
+    "destination": "https://${ZOWE_EXTERNAL_HOST}:${ZWE_EXTERNAL_PORT}/ui/v1/explorer-uss",
     "launchDefinition": {
       "pluginShortNameKey": "USS Explorer",
       "pluginShortNameDefault": "USS Explorer", 


### PR DESCRIPTION
Signed-off-by: Jack (T.) Jia <jack-tiefeng.jia@ibm.com>

This PR addresses Issue: explorer apps are not loaded if accessing from 8544 port.

## PR Type
- [x] Bug fix
- [ ] Feature
- [ ] Other (Please indicate)

## PR Checklist
- [ ] PR completes `npm run preCommit` without error
- [ ] Relevant Test cases have been added (Unit and or FVT)
- [ ] Relevant update to CHANGELOG.md
- [ ] PR from forked repo? Ensure Allow edits by maintaners is set.