### PR TITLE
Progress indicator

### DIFF
--- a/WebContent/js/reducers/treeUSS.js
+++ b/WebContent/js/reducers/treeUSS.js
@@ -20,6 +20,7 @@ import {
     RECEIVE_DELETE_RESOURCE,
     INVALIDATE_USS_TREE_CHILDREN,
 } from '../actions/treeUSS';
+import { REQUEST_CONTENT, RECEIVE_CONTENT, INVALIDATE_CONTENT } from '../actions/editor';
 import { getResourceFromPath } from '../utilities/USSUtilities';
 
 export const ROOT_TREE_ID = 'treeUSS';
@@ -86,6 +87,11 @@ export default function treeUSS(state = INITIAL_TREE_STATE, action) {
             }
             return state;
         }
+        case REQUEST_CONTENT:
+            return state.set('isFetching', true);
+        case RECEIVE_CONTENT:
+        case INVALIDATE_CONTENT:
+            return state.set('isFetching', false);
         default:
             return state;
     }


### PR DESCRIPTION
This PR addresses Issue: [#318](https://github.com/zowe/zlux/issues/318)

## PR Type
- [x] Feature

## PR Checklist
- [x] PR completes `npm run preCommit` without error

## Notes
Progress indicator is spinning when (a large) file is being retrieved.
File ```longfile.txt``` is being retrieved:
![image](https://user-images.githubusercontent.com/66114686/163391409-728b5684-4247-4d65-95a5-816e80afa24a.png)
File is retrieved:
![image](https://user-images.githubusercontent.com/66114686/163391487-be553bb6-7b6f-4c40-9252-3d73056de8f1.png)

