### PR TITLE
Fix endpoint for v3 zosmf route

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -62,7 +62,7 @@ jobs:
         uses: zowe-actions/shared-actions/prepare-workflow@main
           
       - name: '[Prep 5] Setup Node'
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 16
 

--- a/WebContent/js/utilities/urlUtils.js
+++ b/WebContent/js/utilities/urlUtils.js
@@ -26,7 +26,7 @@ const ZOSMF_PREFIX_LENGTH = 6;
 
 function atlasAction(endpoint, content, fetchParams) {
     // In v3, /ibmzosmf/api/v1 endpoint removes /zosmf part of a /zosmf URL, so string must be trimmed.
-    let trimmedEndpoint = endpoint.substring(ZOSMF_PREFIX_LENGTH);
+    const trimmedEndpoint = endpoint.substring(ZOSMF_PREFIX_LENGTH);
 
     return fetch(`https://${whichServer()}/ibmzosmf/api/v1/zosmf/${trimmedEndpoint}`, { ...fetchParams, ...content });
 }

--- a/WebContent/js/utilities/urlUtils.js
+++ b/WebContent/js/utilities/urlUtils.js
@@ -20,7 +20,6 @@ export function whichServer() {
     return server;
 }
 
-
 // zosmf/
 const ZOSMF_PREFIX_LENGTH = 6;
 

--- a/WebContent/js/utilities/urlUtils.js
+++ b/WebContent/js/utilities/urlUtils.js
@@ -20,7 +20,14 @@ export function whichServer() {
     return server;
 }
 
+
+// zosmf/
+const ZOSMF_PREFIX_LENGTH = 6;
+
 function atlasAction(endpoint, content, fetchParams) {
+    // In v3, /ibmzosmf/api/v1 endpoint removes /zosmf part of a /zosmf URL, so string must be trimmed.
+    endpoint = endpoint.substring(ZOSMF_PREFIX_LENGTH);
+
     return fetch(`https://${whichServer()}/ibmzosmf/api/v1/zosmf/${endpoint}`, { ...fetchParams, ...content });
 }
 

--- a/WebContent/js/utilities/urlUtils.js
+++ b/WebContent/js/utilities/urlUtils.js
@@ -26,9 +26,9 @@ const ZOSMF_PREFIX_LENGTH = 6;
 
 function atlasAction(endpoint, content, fetchParams) {
     // In v3, /ibmzosmf/api/v1 endpoint removes /zosmf part of a /zosmf URL, so string must be trimmed.
-    endpoint = endpoint.substring(ZOSMF_PREFIX_LENGTH);
+    let trimmedEndpoint = endpoint.substring(ZOSMF_PREFIX_LENGTH);
 
-    return fetch(`https://${whichServer()}/ibmzosmf/api/v1/zosmf/${endpoint}`, { ...fetchParams, ...content });
+    return fetch(`https://${whichServer()}/ibmzosmf/api/v1/zosmf/${trimmedEndpoint}`, { ...fetchParams, ...content });
 }
 
 export function atlasGet(endpoint, content) {

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -17,12 +17,12 @@ FROM zowe-docker-release.jfrog.io/ompzowe/base-node:${ZOWE_BASE_IMAGE} AS builde
 ##################################
 # labels
 LABEL name="USS Explorer" \
-      maintainer="jack-tiefeng.jia@ibm.com" \
-      vendor="Zowe" \
-      version="0.0.0" \
-      release="0" \
-      summary="IBM z/OS Unix Files UI service" \
-      description="This Zowe UI component can display unix files on z/OS"
+    maintainer="jack-tiefeng.jia@ibm.com" \
+    vendor="Zowe" \
+    version="0.0.0" \
+    release="0" \
+    summary="IBM z/OS Unix Files UI service" \
+    description="This Zowe UI component can display unix files on z/OS"
 
 ##################################
 # switch context
@@ -37,6 +37,7 @@ COPY --chown=zowe:zowe component .
 # build component
 # pretty same as .pax/prepare-workspace.sh. any way we can merge?
 RUN npm ci --no-audit --ignore-scripts \
+    && npm install -g npm@7.24.2 \
     && npm run prod \
     && mkdir -p final/web \
     && cp README.md final \

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -37,7 +37,6 @@ COPY --chown=zowe:zowe component .
 # build component
 # pretty same as .pax/prepare-workspace.sh. any way we can merge?
 RUN npm ci --no-audit --ignore-scripts \
-    && npm install -g npm@7.24.2 \
     && npm run prod \
     && mkdir -p final/web \
     && cp README.md final \

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -5,7 +5,7 @@ id: org.zowe.explorer-uss
 # Component version is defined in gradle.properties for Gradle project
 # Human readable component name
 title: USS Explorer
-version: 2.0.7
+version: 2.0.9
 # Human readable component description
 description: IBM z/OS Unix Files UI service
 license: EPL-2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@material-ui/core": "4.11.0",
         "@material-ui/icons": "4.9.1",
         "babel-polyfill": "6.16.0",
-        "immutable": "3.8.1",
+        "immutable": "3.8.2",
         "interweave": "8.0.1",
         "lowlight": "2.4.0",
         "orion-editor-component": "0.0.14",
@@ -7203,9 +7203,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "3.8.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/immutable/-/immutable-3.8.1.tgz",
-      "integrity": "sha512-0R2q5f83L0h+zizu3lAA3ZR/mzEl04U1jVVXIqf2rQbZs9eX5YGtx1EFQuuJJHzVXH10ur6hGKehR8yBOQmZlQ==",
+      "version": "3.8.2",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/immutable/-/immutable-3.8.2.tgz",
+      "integrity": "sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -19142,9 +19142,9 @@
       "dev": true
     },
     "immutable": {
-      "version": "3.8.1",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/immutable/-/immutable-3.8.1.tgz",
-      "integrity": "sha512-0R2q5f83L0h+zizu3lAA3ZR/mzEl04U1jVVXIqf2rQbZs9eX5YGtx1EFQuuJJHzVXH10ur6hGKehR8yBOQmZlQ=="
+      "version": "3.8.2",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/immutable/-/immutable-3.8.2.tgz",
+      "integrity": "sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg=="
     },
     "import-fresh": {
       "version": "3.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "explorer-uss",
-  "version": "2.0.8",
+  "version": "2.0.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "explorer-uss",
-      "version": "2.0.8",
+      "version": "2.0.10",
       "license": "EPL-2.0",
       "dependencies": {
         "@material-ui/core": "4.11.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@material-ui/core": "4.11.0",
     "@material-ui/icons": "4.9.1",
     "babel-polyfill": "6.16.0",
-    "immutable": "3.8.1",
+    "immutable": "3.8.2",
     "interweave": "8.0.1",
     "lowlight": "2.4.0",
     "orion-editor-component": "0.0.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "explorer-uss",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "types": "module",
   "directories": {
     "test": "tests"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "explorer-uss",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "types": "module",
   "directories": {
     "test": "tests"

--- a/tests/testResources/hostConstants.js
+++ b/tests/testResources/hostConstants.js
@@ -11,4 +11,4 @@
 export const LOCAL_HOSTNAME = 'tester.test.com';
 export const LOCAL_HOST_SERVER = `${LOCAL_HOSTNAME}:7443`;
 export const LOCAL_HOST_SERVER_WITH_PROTOCOL = `https://${LOCAL_HOST_SERVER}`;
-export const LOCAL_HOST_ENDPOINT = `${LOCAL_HOST_SERVER_WITH_PROTOCOL}/ibmzosmf/api/v1/zosmf/`;
+export const LOCAL_HOST_ENDPOINT = `${LOCAL_HOST_SERVER_WITH_PROTOCOL}/ibmzosmf/api/v1/`;


### PR DESCRIPTION
In v3, /ibmzosmf/api/v1 endpoint removes /zosmf part of a /zosmf URL.
All URLs to zosmf in explorers are in form of 'zosmf/rest...' and are prefixed with APIML route in a single function.
So in this function, a substring operation is performed.